### PR TITLE
openshift template to deploy the cronjob

### DIFF
--- a/openshift/buildConfig-template.yaml
+++ b/openshift/buildConfig-template.yaml
@@ -1,0 +1,153 @@
+apiVersion: v1
+kind: Template
+metadata:
+  name: graph-backup-buildconfig
+  annotations:
+    description: >
+      This is Thoth Graph Backup CronJob BuildConfig, this template is meant to be used by Bots,
+      but could also be used by humans...
+    openshift.io/display-name: "Thoth: Graph Backup Job BuildConfig"
+    version: 0.1.0
+    tags: thoth,graph-backup,ai-stacks,aistacks,graph
+    template.openshift.io/documentation-url: https://github.com/Thoth-Station/
+    template.openshift.io/long-description: >
+      This template defines resources needed to deploy Thoth Graph Backup Job BuildConfig to OpenShift.
+    template.openshift.io/provider-display-name: Red Hat, Inc.
+    thoth-station.ninja/template-version: 0.1.0
+  labels:
+    template: graph-backup-buildconfig
+    app: thoth
+    component: configmap
+
+objects:
+  - kind: BuildConfig
+    apiVersion: build.openshift.io/v1
+    metadata:
+      name: s2i-thoth-ubi8-py36-postgres
+      annotations:
+        thoth-station.ninja/template-version: 0.1.0
+      labels:
+        app: thoth
+        component: graph-backup
+    spec:
+      resources:
+        requests:
+          memory: "256Mi"
+          cpu: "500m"
+        limits:
+          memory: "256Mi"
+          cpu: "500m"
+      output:
+        to:
+          kind: ImageStreamTag
+          name: "s2i-thoth-ubi8-py36-postgres:${IMAGE_STREAM_TAG}"
+      source:
+        dockerfile: |
+          FROM s2i-thoth-ubi8-py36:latest
+          ENV LANG=en_US.UTF-8
+          USER 0
+          RUN dnf install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-8-x86_64/pgdg-redhat-repo-latest.noarch.rpm
+          RUN dnf update -y
+          RUN dnf install -y postgresql96
+          USER 1001
+        type: Git
+        git:
+          uri: ${GITHUB_URL}
+          ref: ${GITHUB_REF}
+      strategy:
+        type: Docker
+        dockerStrategy:
+          from:
+            kind: ImageStreamTag
+            name: s2i-thoth-ubi8-py36:latest
+      triggers:
+        - type: ConfigChange
+        - type: ImageChange
+          imageChange: {}
+        - type: Generic
+          generic:
+            secretReference:
+              name: generic-webhook-secret
+
+  - kind: BuildConfig
+    apiVersion: build.openshift.io/v1
+    metadata:
+      name: graph-backup-job
+      annotations:
+        thoth-station.ninja/template-version: 0.1.0
+      labels:
+        app: thoth
+        component: graph-backup
+    spec:
+      resources:
+        limits:
+          cpu: 1
+          memory: 768Mi
+        requests:
+          cpu: 1
+          memory: 768Mi
+      output:
+        to:
+          kind: ImageStreamTag
+          name: "graph-backup-job:${IMAGE_STREAM_TAG}"
+      source:
+        type: Git
+        git:
+          uri: ${GITHUB_URL}
+          ref: ${GITHUB_REF}
+      strategy:
+        type: Source
+        sourceStrategy:
+          from:
+            kind: ImageStreamTag
+            name: s2i-thoth-ubi8-py36-postgres:latest
+          env:
+            - name: ENABLE_PIPENV
+              value: '1'
+            - name: UPGRADE_PIP_TO_LATEST
+              value: ''
+            - name: "THOTH_DRY_RUN"
+              value: "1"
+            - name: "THOTH_ADVISE"
+              value: ${THOTH_ADVISE}
+            - name: "THAMOS_VERBOSE"
+              value: "1"
+            - name: "THAMOS_DEBUG"
+              value: "1"
+            - name: "THAMOS_CONFIG_TEMPLATE"
+              value: ".thothTemplate.yaml"
+            - name: "THAMOS_CONFIG_EXPAND_ENV"
+              value: "1"
+      triggers:
+        - type: ConfigChange
+        - type: ImageChange
+          imageChange: {}
+        - type: Generic
+          generic:
+            secretReference:
+              name: generic-webhook-secret
+
+parameters:
+  - description: Name of the GitHub repository for Thoth's Graph Backup Job
+    displayName: Git Repository
+    required: true
+    name: GITHUB_URL
+    value: 'https://github.com/thoth-station/graph-backup-job'
+
+  - description: Git reference to be used for Thoth's Graph Backup Job
+    displayName: Git Reference
+    required: true
+    name: GITHUB_REF
+    value: 'master'
+
+  - description: Tag of the output ImageStream the resulting container image should go to
+    displayName: ImageStream Tag
+    required: true
+    name: IMAGE_STREAM_TAG
+    value: 'latest'
+
+  - description: Thamos Advise setup tag value
+    displayName: THOTH_ADVISE
+    required: true
+    name: THOTH_ADVISE
+    value: "1"

--- a/openshift/cronJob-template.yaml
+++ b/openshift/cronJob-template.yaml
@@ -1,0 +1,158 @@
+apiVersion: v1
+kind: Template
+metadata:
+  name: graph-backup-cronjob
+  annotations:
+    description: >
+      This is Thoth Graph Backup CronJob CronJob, this template is meant to be used by Bots,
+      but could also be used by humans...
+    openshift.io/display-name: "Thoth: Graph Backup Job"
+    version: 0.1.0
+    tags: thoth,graph-backup,ai-stacks,aistacks,graph
+    template.openshift.io/documentation-url: https://github.com/Thoth-Station/
+    template.openshift.io/long-description: >
+      This template defines resources needed to deploy Thoth Graph Backup Job CronJob to OpenShift.
+    template.openshift.io/provider-display-name: "Red Hat, Inc."
+    thoth-station.ninja/template-version: 0.1.0
+  labels:
+    template: graph-backup-cronjob
+    app: thoth
+    component: graph-backup
+
+parameters:
+  - description: Registry the ImageStream to be use lives in
+    displayName: ImageStream Registry
+    required: true
+    name: IMAGE_STREAM_REGISTRY
+    value: "docker-registry.default.svc:5000"
+
+  - displayName: Suspend CronJob run
+    description: Suspend CronJob run
+    required: true
+    name: THOTH_SUSPEND_JOB
+    value: "true"
+
+  - description: Project the ImageStream to be use lives in
+    displayName: ImageStream Project
+    required: true
+    name: IMAGE_STREAM_NAMESPACE
+    value: "thoth-infra-stage"
+
+  - description: Tag of the ImageStream to be use
+    displayName: ImageStream Tag
+    required: true
+    name: IMAGE_STREAM_TAG
+    value: "latest"
+
+objects:
+  - kind: CronJob
+    apiVersion: batch/v1beta1
+    metadata:
+      name: graph-backup
+      annotations:
+        thoth-station.ninja/template-version: 0.1.0
+      labels:
+        app: thoth
+        component: graph-backup
+    spec:
+      schedule: "@daily"
+      suspend: ${{THOTH_SUSPEND_JOB}}
+      concurrencyPolicy: Forbid
+      successfulJobsHistoryLimit: 2
+      failedJobsHistoryLimit: 4
+      startingDeadlineSeconds: 5000000
+      jobTemplate:
+        spec:
+          template:
+            metadata:
+              labels:
+                app: thoth
+                component: graph-backup
+            spec:
+              serviceAccountName: "graph-backup-job"
+              containers:
+                - image: "${IMAGE_STREAM_REGISTRY}/${IMAGE_STREAM_NAMESPACE}/graph-backup-job:${IMAGE_STREAM_TAG}"
+                  name: graph-backup
+                  env:
+                    - name: THOTH_DEPLOYMENT_NAME
+                      valueFrom:
+                        configMapKeyRef:
+                          key: storage-bucket-name
+                          name: thoth
+                    - name: THOTH_S3_ENDPOINT_URL
+                      valueFrom:
+                        configMapKeyRef:
+                          key: ceph-host
+                          name: thoth
+                    - name: THOTH_CEPH_BUCKET
+                      valueFrom:
+                        configMapKeyRef:
+                          key: ceph-bucket-name
+                          name: thoth
+                    - name: THOTH_CEPH_BUCKET_PREFIX
+                      valueFrom:
+                        configMapKeyRef:
+                          key: ceph-bucket-prefix
+                          name: thoth
+                    - name: THOTH_CEPH_KEY_ID
+                      valueFrom:
+                        secretKeyRef:
+                          name: thoth
+                          key: ceph-key-id
+                    - name: THOTH_CEPH_SECRET_KEY
+                      valueFrom:
+                        secretKeyRef:
+                          name: thoth
+                          key: ceph-secret-key
+                    - name: RSYSLOG_HOST
+                      valueFrom:
+                      configMapKeyRef:
+                        key: rsyslog-host
+                        name: thoth
+                    - name: RSYSLOG_PORT
+                      valueFrom:
+                      configMapKeyRef:
+                        key: rsyslog-port
+                        name: thoth
+                    - name: SENTRY_DSN
+                      valueFrom:
+                        secretKeyRef:
+                          name: thoth
+                          key: sentry-dsn
+                    - name: PROMETHEUS_PUSHGATEWAY_URL
+                      valueFrom:
+                        configMapKeyRef:
+                          name: thoth
+                          key: metrics-pushgateway-url
+                    - name: KNOWLEDGE_GRAPH_HOST
+                      valueFrom:
+                        configMapKeyRef:
+                          key: postgresql-host
+                          name: thoth
+                    - name: KNOWLEDGE_GRAPH_PORT
+                      value: "5432"
+                    - name: KNOWLEDGE_GRAPH_SSL_DISABLED
+                      value: "1"
+                    - name: KNOWLEDGE_GRAPH_USER
+                      valueFrom:
+                        secretKeyRef:
+                          name: postgresql
+                          key: database-user
+                    - name: KNOWLEDGE_GRAPH_PASSWORD
+                      valueFrom:
+                        secretKeyRef:
+                          name: postgresql
+                          key: database-password
+                    - name: KNOWLEDGE_GRAPH_DATABASE
+                      valueFrom:
+                        secretKeyRef:
+                          name: postgresql
+                          key: database-name
+                  resources:
+                    requests:
+                      memory: "256Mi"
+                      cpu: "500m"
+                    limits:
+                      memory: "256Mi"
+                      cpu: "500m"
+              restartPolicy: OnFailure

--- a/openshift/imageStream-template.yaml
+++ b/openshift/imageStream-template.yaml
@@ -1,0 +1,50 @@
+apiVersion: v1
+kind: Template
+metadata:
+  name: graph-backup-imagestream
+  annotations:
+    description: >
+      This is Thoth Graph Backup CronJob ImageStream, this template is meant to be used by Bots,
+      but could also be used by humans...
+    openshift.io/display-name: "Thoth: Graph Backup Job ImageStream"
+    version: 0.1.0
+    tags: thoth,graph-backup,ai-stacks,aistacks,graph
+    template.openshift.io/documentation-url: https://github.com/Thoth-Station/
+    template.openshift.io/long-description: >
+      This template defines resources needed to deploy Thoth Graph Backup Job ImageStream to OpenShift.
+    template.openshift.io/provider-display-name: Red Hat, Inc.
+    thoth-station.ninja/template-version: 0.1.0
+  labels:
+    template: graph-backup-imagestream
+    thoth: 0.1.0
+    app: thoth
+    component: graph-backup
+
+objects:
+  - kind: ImageStream
+    apiVersion: image.openshift.io/v1
+    metadata:
+      annotations:
+        thoth-station.ninja/template-version: 0.1.0
+      labels:
+        app: thoth
+        component: graph-backup
+      name: s2i-thoth-ubi8-py36-postgres
+    spec:
+      name: latest
+      lookupPolicy:
+        local: true
+
+  - kind: ImageStream
+    apiVersion: image.openshift.io/v1
+    metadata:
+      annotations:
+        thoth-station.ninja/template-version: 0.1.0
+      labels:
+        app: thoth
+        component: graph-backup
+      name: graph-backup-job
+    spec:
+      name: latest
+      lookupPolicy:
+        local: true


### PR DESCRIPTION
openshift template to deploy the cronjob
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Related Issues and Dependencies
Depend-On: #4 

## This introduces a breaking change

- [ ] Yes
- [x] No

## This Pull Request implements

Openshift template to deploy the application as a cronjob on openshift

## Description

The openshift template for deploying the application as a cronjob. Template includes :
buildconfig, imagestream, cronjob.