### PR TITLE
Do not use timeout in run command

### DIFF
--- a/app.py
+++ b/app.py
@@ -52,7 +52,7 @@ def main():
     backup_file_dest = os.path.abspath(backup_file_name)
 
     _LOGGER.info("Starting the subprocess to take the dump from database.")
-    sub_process = run_command(
+    run_command(
         f"pg_dump -h {KNOWLEDGE_GRAPH_HOST} -p {KNOWLEDGE_GRAPH_PORT} -U {KNOWLEDGE_GRAPH_USER} -d {KNOWLEDGE_GRAPH_DATABASE} -f {backup_file_dest}"
     )
     _LOGGER.info("upload the database backup file to ceph storage.")

--- a/app.py
+++ b/app.py
@@ -53,7 +53,7 @@ def main():
 
     _LOGGER.info("Starting the subprocess to take the dump from database.")
     run_command(
-        f"pg_dump -h {KNOWLEDGE_GRAPH_HOST} -p {KNOWLEDGE_GRAPH_PORT} -U {KNOWLEDGE_GRAPH_USER} -d {KNOWLEDGE_GRAPH_DATABASE} -f {backup_file_dest}"
+        f"pg_dump -h {KNOWLEDGE_GRAPH_HOST} -p {KNOWLEDGE_GRAPH_PORT} -U {KNOWLEDGE_GRAPH_USER} -d {KNOWLEDGE_GRAPH_DATABASE} -f {backup_file_dest}", timeout=None
     )
     _LOGGER.info("upload the database backup file to ceph storage.")
     try:


### PR DESCRIPTION
## Related Issues and Dependencies

#10 

## This introduces a breaking change

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## This Pull Request implements

The `run_command` function has a default timeout set to 60 seconds. This
timeout will not be sufficient when performing backups of larger database (e.g.
our stage environment). Let's remove restriction on timeout and let okd/k8s
handle job liveness as described in  #10.

## Description

<!--- Describe your changes in detail -->