### PR TITLE
Add liveness probe

### DIFF
--- a/openshift/cronJob-template.yaml
+++ b/openshift/cronJob-template.yaml
@@ -155,4 +155,10 @@ objects:
                     limits:
                       memory: "256Mi"
                       cpu: "500m"
+                  livenessProbe:
+                    tcpSocket:
+                      port: 80
+                    initialDelaySeconds: 7200
+                    failureThreshold: 1
+                    periodSeconds: 10
               restartPolicy: OnFailure


### PR DESCRIPTION
## Related Issues and Dependencies

#9

## This introduces a breaking change

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## This Pull Request implements


Let job do its job in 2 hours, kill it if it does not succeed. As we do not
have port 80 opened, the liveness probe will always fail after initial delay
seconds.

## Description

<!--- Describe your changes in detail -->