### PR TITLE
thoth-s2i based dockerfile for postgresql

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM quay.io/thoth-station/s2i-thoth-ubi8-py36:latest
+ENV LANG=en_US.UTF-8
+USER 0
+RUN yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-8-x86_64/pgdg-redhat-repo-latest.noarch.rpm \
+  && yum update -y \
+  && yum install -y --setopt=tsflags=nodocs postgresql96
+USER 1001

--- a/openshift/buildConfig-template.yaml
+++ b/openshift/buildConfig-template.yaml
@@ -17,58 +17,9 @@ metadata:
   labels:
     template: graph-backup-buildconfig
     app: thoth
-    component: configmap
+    component: graph-backup
 
 objects:
-  - kind: BuildConfig
-    apiVersion: build.openshift.io/v1
-    metadata:
-      name: s2i-thoth-ubi8-py36-postgres
-      annotations:
-        thoth-station.ninja/template-version: 0.1.0
-      labels:
-        app: thoth
-        component: graph-backup
-    spec:
-      resources:
-        requests:
-          memory: "256Mi"
-          cpu: "500m"
-        limits:
-          memory: "256Mi"
-          cpu: "500m"
-      output:
-        to:
-          kind: ImageStreamTag
-          name: "s2i-thoth-ubi8-py36-postgres:${IMAGE_STREAM_TAG}"
-      source:
-        dockerfile: |
-          FROM s2i-thoth-ubi8-py36:latest
-          ENV LANG=en_US.UTF-8
-          USER 0
-          RUN dnf install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-8-x86_64/pgdg-redhat-repo-latest.noarch.rpm
-          RUN dnf update -y
-          RUN dnf install -y postgresql96
-          USER 1001
-        type: Git
-        git:
-          uri: ${GITHUB_URL}
-          ref: ${GITHUB_REF}
-      strategy:
-        type: Docker
-        dockerStrategy:
-          from:
-            kind: ImageStreamTag
-            name: s2i-thoth-ubi8-py36:latest
-      triggers:
-        - type: ConfigChange
-        - type: ImageChange
-          imageChange: {}
-        - type: Generic
-          generic:
-            secretReference:
-              name: generic-webhook-secret
-
   - kind: BuildConfig
     apiVersion: build.openshift.io/v1
     metadata:

--- a/openshift/imageStream-template.yaml
+++ b/openshift/imageStream-template.yaml
@@ -29,20 +29,6 @@ objects:
       labels:
         app: thoth
         component: graph-backup
-      name: s2i-thoth-ubi8-py36-postgres
-    spec:
-      name: latest
-      lookupPolicy:
-        local: true
-
-  - kind: ImageStream
-    apiVersion: image.openshift.io/v1
-    metadata:
-      annotations:
-        thoth-station.ninja/template-version: 0.1.0
-      labels:
-        app: thoth
-        component: graph-backup
       name: graph-backup-job
     spec:
       name: latest


### PR DESCRIPTION
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Related Issues and Dependencies
The s2i-thoth-ubi-py36-postgres is having issue building in the PSI infrastructure, which blocks the graph-backup-job for building.

## This introduces a breaking change

- [] Yes
- [x] No

## This Pull Request implements

Converts the buildconfig dockerfile content to a Dockerfile.

## Description

With the PR, the idea is to use quay to build the s2i-thoth-ubi-py36-postgres for time being until the building on PSI infrastructure is fixed.  we would step trigger for quay to build from the Dockerfile, and we use the image in PSI infrastructure to build `graph-backup-job`.
Follow up:

- create a repo in thoth-station quay for s2i-thoth-ubi-py36-postgres. 
- step a trigger to build from github repo Dockerfile.
- tag that in quay for use.