### PR TITLE
thothTemplate required for thoth advise

### DIFF
--- a/.thoth.yaml
+++ b/.thoth.yaml
@@ -3,9 +3,9 @@ tls_verify: false
 requirements_format: pipenv
 
 runtime_environments:
-  - name: 'ubi:8'
+  - name: "rhel:8.0"
     operating_system:
-      name: ubi
-      version: "8"
+      name: "rhel"
+      version: "8.0"
     python_version: "3.6"
     recommendation_type: latest

--- a/.thothTemplate.yaml
+++ b/.thothTemplate.yaml
@@ -1,0 +1,14 @@
+host: '{THOTH_HOST}'
+tls_verify: false
+requirements_format: pipenv
+
+runtime_environments:
+  - name: '{os_name}:{os_version}'
+    operating_system:
+      name: '{os_name}'
+      version: '{os_version}'
+    hardware:
+      cpu_family: {cpu_family}
+      cpu_model: {cpu_model}
+    python_version: '{python_version}'
+    recommendation_type: STABLE

--- a/openshift/buildConfig-template.yaml
+++ b/openshift/buildConfig-template.yaml
@@ -66,7 +66,7 @@ objects:
             - name: "THAMOS_DEBUG"
               value: "1"
             - name: "THAMOS_CONFIG_TEMPLATE"
-              value: ".thothTemplate.yaml"
+              value: ".thoth.yaml"
             - name: "THAMOS_CONFIG_EXPAND_ENV"
               value: "1"
       triggers:


### PR DESCRIPTION
thothTemplate required for thoth advise
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## This introduces a breaking change

- [x] Yes
- [ ] No

The build with thoth-advise fails as it looks for .thothTemplate.
## This Pull Request implements

Introduced the .thothTemplate.yaml

## Description

standard template file required for thoth advise :smile: 