### PR TITLE
Do not run adviser from bc in debug mode

### DIFF
--- a/openshift/buildConfig-template.yaml
+++ b/openshift/buildConfig-template.yaml
@@ -64,7 +64,7 @@ objects:
             - name: "THAMOS_VERBOSE"
               value: "1"
             - name: "THAMOS_DEBUG"
-              value: "1"
+              value: "0"
             - name: "THAMOS_CONFIG_TEMPLATE"
               value: ".thoth.yaml"
             - name: "THAMOS_CONFIG_EXPAND_ENV"


### PR DESCRIPTION
Do not run adviser from bc in debug mode
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>
## This introduces a breaking change

- [ ] Yes
- [ x] No

