### PR TITLE
not all updates are required for postgresql10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,5 @@ FROM quay.io/thoth-station/s2i-thoth-ubi8-py36:latest
 ENV LANG=en_US.UTF-8
 USER 0
 RUN yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-8-x86_64/pgdg-redhat-repo-latest.noarch.rpm \
-  && yum update -y \
   && yum install -y --setopt=tsflags=nodocs postgresql10
 USER 1001


### PR DESCRIPTION
not all updates are required for postgresql10
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Related Issues and Dependencies

Builds fails for updating for postgresql 12 
```
Error: Problem 1: cannot install the best update candidate for package libpq-devel-12.1-3.el8.x86_64 - nothing provides clang-devel >= 8.0.1 needed by postgresql12-devel-12.3-5PGDG.rhel8.x86_64 - nothing provides llvm-devel >= 8.0.1 needed by postgresql12-devel-12.3-5PGDG.rhel8.x86_64 - nothing provides clang-devel >= 8.0.1 needed by postgresql11-devel-11.8-2PGDG.rhel8.x86_64 - nothing provides llvm-devel >= 8.0.1 
...
```
dont need it for postgresql 10 

## This introduces a breaking change

- [x] No
